### PR TITLE
Changing background color for debug toolbar

### DIFF
--- a/themes/monokai-one-dark-vivid-color-theme.json
+++ b/themes/monokai-one-dark-vivid-color-theme.json
@@ -54,6 +54,7 @@
     "titleBar.activeForeground": "#747D91",
     "titleBar.inactiveBackground": "#131c28",
     "titleBar.inactiveForeground": "#747D9160",
+    "debugToolBar.background": "#131c28",
     "editorLink.activeForeground": "#ffffff"
   },
   "tokenColors": [


### PR DESCRIPTION
Hi Ash.

Love this theme! Been using it for about a year now.
I figured I would propose this tiny change, since I noticed the debug toolbar uses the default dark background color. I'm guessing you don't use debug features/toolbar?

I used the same color you use for the tab bar & the find bar.

Thanks!
